### PR TITLE
Fixed adwords inclusion in responsive template

### DIFF
--- a/Views/Responsive/frontend/checkout/finish.tpl
+++ b/Views/Responsive/frontend/checkout/finish.tpl
@@ -1,6 +1,6 @@
 {extends file="parent:frontend/checkout/finish.tpl"}
 
-{block name='frontend_index_header_javascript_jquery' append}
+{block name='frontend_index_header_javascript_tracking' append}
     {if $sOrderNumber || $sTransactionumber}
         {include file="SwagGoogle/adwords.tpl"}
     {/if}


### PR DESCRIPTION
The old frontend_index_header_javascript_jquery block does not exist in the header of the new template which leads to the adwords code not being included in the finish action of the checkout.
