### PR TITLE
Adding Google Optimize Elements & Configuration

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -107,6 +107,12 @@ class Shopware_Plugins_Frontend_SwagGoogle_Bootstrap extends Shopware_Components
             'value' => null,
             'scope' => Element::SCOPE_SHOP
         ]);
+        $form->setElement('text', 'optimize_code', [
+            'label' => 'Google Optimize-ID',
+            'value' => null,
+            'description' => 'Um die Funktion von Google Optimize nutzen zu können, muss die Google Universal Analytics Bibliothek genutzt werden.',
+            'scope' => Element::SCOPE_SHOP
+        ]);
         $form->setElement('checkbox', 'anonymize_ip', [
             'label' => 'IP-Adresse anonymisieren',
             'value' => true,
@@ -148,6 +154,10 @@ class Shopware_Plugins_Frontend_SwagGoogle_Bootstrap extends Shopware_Components
                     ],
                     'conversion_code' => [
                         'label' => 'Google Conversion ID'
+                    ],
+                    'optimize_code' => [
+                        'label' => 'Google Optimize-ID',
+                        'description' => 'Google Universal Analytics libary must be selected to use Google Optimize'
                     ],
                     'anonymize_ip' => [
                         'label' => 'Anonymous IP address'
@@ -196,6 +206,7 @@ class Shopware_Plugins_Frontend_SwagGoogle_Bootstrap extends Shopware_Components
         }
         if (!empty($config->tracking_code)) {
             $view->assign('GoogleTrackingID', $config->get('tracking_code'));
+            $view->assign('GoogleOptimizeID', $config->get('optimize_code'));
             $view->assign('GoogleAnonymizeIp', $config->get('anonymize_ip'));
             $view->assign('GoogleOptOutCookie', $config->get('include_opt_out_cookie'));
             $view->assign('GoogleTrackingLibrary', $config->get('trackingLib'));

--- a/Resources/frontend/js/jquery.googleoptimize.js
+++ b/Resources/frontend/js/jquery.googleoptimize.js
@@ -1,0 +1,3 @@
+$.subscribe("plugin/swEmotionLoader/onLoadEmotionFinished", function(me) {
+    dataLayer.push({'event': 'optimize.activate'});
+});

--- a/Views/Common/SwagGoogle/ua.tpl
+++ b/Views/Common/SwagGoogle/ua.tpl
@@ -59,7 +59,9 @@
             {/foreach}
             ga('ecommerce:send');
         {/if}
-
+        {if $GoogleOptimizeID}
+            ga('require', '{$GoogleOptimizeID|escape:'javascript'}');
+        {/if}
         ga('send', 'pageview');
     })();
     //]]>

--- a/Views/frontend/checkout/finish.tpl
+++ b/Views/frontend/checkout/finish.tpl
@@ -2,7 +2,8 @@
 
 {block name='frontend_index_header_javascript_jquery'}
     {$smarty.block.parent}
+    {block name="frontend_index_header_google_adwords"}
     {if $sOrderNumber || $sTransactionumber}
         {include file="SwagGoogle/adwords.tpl"}
     {/if}
-{/block}
+{/block}{/block}

--- a/Views/frontend/index/header.tpl
+++ b/Views/frontend/index/header.tpl
@@ -2,14 +2,16 @@
 
 {block name="frontend_index_header_javascript_tracking"}
     {$smarty.block.parent}
-    {if $GoogleIncludeInHead && $GoogleTrackingID}
-        {if $GoogleOptOutCookie}
-            {include file="SwagGoogle/optout.tpl"}
+    {block name="frontend_index_header_google_analytics"}
+        {if $GoogleIncludeInHead && $GoogleTrackingID}
+            {if $GoogleOptOutCookie}
+                {include file="SwagGoogle/optout.tpl"}
+            {/if}
+            {if $GoogleTrackingLibrary == 'ga'}
+                {include file="SwagGoogle/analytics.tpl"}
+            {else}
+                {include file="SwagGoogle/ua.tpl"}
+            {/if}
         {/if}
-        {if $GoogleTrackingLibrary == 'ga'}
-            {include file="SwagGoogle/analytics.tpl"}
-        {else}
-            {include file="SwagGoogle/ua.tpl"}
-        {/if}
-    {/if}
+    {/block}
 {/block}

--- a/Views/frontend/index/index.tpl
+++ b/Views/frontend/index/index.tpl
@@ -2,14 +2,16 @@
 
 {block name="frontend_index_header_javascript_jquery"}
     {$smarty.block.parent}
-    {if !$GoogleIncludeInHead && $GoogleTrackingID}
-        {if $GoogleOptOutCookie}
-            {include file="SwagGoogle/optout.tpl"}
+    {block name="frontend_index_header_google_analytics"}
+        {if !$GoogleIncludeInHead && $GoogleTrackingID}
+            {if $GoogleOptOutCookie}
+                {include file="SwagGoogle/optout.tpl"}
+            {/if}
+            {if $GoogleTrackingLibrary == 'ga'}
+                {include file="SwagGoogle/analytics.tpl"}
+            {else}
+                {include file="SwagGoogle/ua.tpl"}
+            {/if}
         {/if}
-        {if $GoogleTrackingLibrary == 'ga'}
-            {include file="SwagGoogle/analytics.tpl"}
-        {else}
-            {include file="SwagGoogle/ua.tpl"}
-        {/if}
-    {/if}
+    {/block}
 {/block}

--- a/plugin.json
+++ b/plugin.json
@@ -8,10 +8,11 @@
     "link": "http://store.shopware.com",
     "author": "Shopware AG",
 
-    "currentVersion": "2.0.8",
+    "currentVersion": "2.0.9",
 
     "changelog": {  
         "de": {
+            "2.0.9": "Integration von Google Optimize. Anlegen von Smarty Blöcken für Google im Template",
             "2.0.8": "PT-8543 - Bugfix: Die Template Ordner werden früher registriert um den SmartySecurity Fehler zu verhindern",
             "2.0.7": "PT-7264 - Bugfix: GA-Tracking über ein Cookie unterbinden;",
             "2.0.6": "PT-7264 - Neue Funktion: GA-Tracking über ein Cookie unterbinden: (<a href=\"javascript:gaOptout()\">Klicken um Datenfluss nach Google zu sperren.</a>).",
@@ -23,6 +24,7 @@
             "2.0.0": "Als Plugin ausgelagert;"
         },
         "en": {
+            "2.0.9": "Integrating google optimize. Add Smarty blocks for google analytics in template",
             "2.0.8": "PT-8543 - Bugfix: The template folders are registered earlier to prevent the SmartySecurity error",
             "2.0.7": "PT-7264 - Bugfix: GA-Tracking über ein Cookie unterbinden;",
             "2.0.6": "PT-7264 - New feature: GA-Tracking can be disabled via Cookie: (<a href=\"javascript:gaOptout()\">Click here to opt-out of Google Analytics</a>",


### PR DESCRIPTION
- Adding Google Optimize Backend Elements:
Bootstrap Field for Optimize ID, Description & Translations

- Adding Google Optimize Frontend Elements:
Google Optimize Snippet @ ua.tpl with if-rule
Google Optimize js file for loading google optimize after Emotion Pages are loaded

- Adding Google Analytics Frontend Smarty Blocks to overwrite Google Analytics Elements in own Template