### PR TITLE
Multidomain possibility for Universal Analytics

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -133,6 +133,16 @@ class Shopware_Plugins_Frontend_SwagGoogle_Bootstrap extends Shopware_Components
             'value' => false,
             'scope' => Element::SCOPE_SHOP
         ]);
+        $form->setElement('checkbox', 'include_multidomain', [
+            'label' => 'Multidomain-Code nutzen',
+            'value' => false,
+            'scope' => Element::SCOPE_SHOP
+        ]);
+        $form->setElement('text', 'multidomain_option', [
+            'label' => 'Multidomain: Weitere Domains (Format: domain1.de, domain2.de)',
+            'value' => null,
+            'scope' => Element::SCOPE_SHOP
+        ]);
         $this->addFormTranslations(
             [
                 'en_GB' => [
@@ -158,6 +168,12 @@ class Shopware_Plugins_Frontend_SwagGoogle_Bootstrap extends Shopware_Components
                     ],
                     'include_header' => [
                         'label' => 'Include the tracking code in the "head" section (Responsive theme)'
+                    ],
+                    'include_multidomain' => [
+                        'label' => 'Use the multidomain-code'
+                    ],
+                    'multidomain_option' => [
+                        'label' => 'Multidomain: Additional domains (format: domain1.com, domain2.com)'
                     ]
                 ]
             ]
@@ -200,6 +216,8 @@ class Shopware_Plugins_Frontend_SwagGoogle_Bootstrap extends Shopware_Components
             $view->assign('GoogleOptOutCookie', $config->get('include_opt_out_cookie'));
             $view->assign('GoogleTrackingLibrary', $config->get('trackingLib'));
             $view->assign('GoogleIncludeInHead', $config->get('include_header'));
+            $view->assign('GoogleIncludeMultidomain', $config->get('include_multidomain'));
+            $view->assign('GoogleMultidomainOption', $config->get('multidomain_option'));
         }
     }
 }

--- a/Views/Common/SwagGoogle/ua.tpl
+++ b/Views/Common/SwagGoogle/ua.tpl
@@ -15,7 +15,13 @@
         })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
         {/literal}
 
-        ga('create', "{$GoogleTrackingID|escape:'javascript'}", 'auto');
+        {if $GoogleIncludeMultidomain}
+            ga('create', "{$GoogleTrackingID|escape:'javascript'}", 'auto', {literal}{'allowLinker': true}{/literal});
+            ga('linker:autoLink', ['{$GoogleMultidomainOption|replace:",":"','"}'] );
+        {else}
+            ga('create', "{$GoogleTrackingID|escape:'javascript'}", 'auto');
+        {/if}
+
         {if $GoogleAnonymizeIp}
             ga('set', 'anonymizeIp', true);
         {/if}


### PR DESCRIPTION
I added the option to set up a multidomain tracking. At this stage, it only works with the universal Analytics code.

I am new to shopware. Is it possible to make backend form dependencies? Like, showing the options field only if multidomain is set to yes.